### PR TITLE
Game State Reducer

### DIFF
--- a/src/context/reducer.ts
+++ b/src/context/reducer.ts
@@ -1,0 +1,274 @@
+import {
+  Cell,
+  CellState,
+  Difficulty,
+  DIFFICULTY_CONFIG,
+  GameState,
+  GameStatus,
+} from "../types";
+import {
+  checkWin,
+  chordReveal,
+  computeAdjacentCounts,
+  countAdjacentFlags,
+  createEmptyBoard,
+  placeMines,
+  revealCell,
+} from "../logic";
+
+// =============================================================================
+// src/context/reducer.ts — action types and gameReducer
+// =============================================================================
+
+const BEST_TIMES_KEY = "minesweeper_best_times";
+
+// ── Action types ──────────────────────────────────────────────────────────────
+
+export type GameAction =
+  | { type: "START_GAME"; difficulty: Difficulty }
+  | { type: "REVEAL_CELL"; row: number; col: number }
+  | { type: "TOGGLE_FLAG"; row: number; col: number }
+  | { type: "CHORD_REVEAL"; row: number; col: number }
+  | { type: "TICK" }
+  | { type: "RESTART" };
+
+// ── localStorage helpers ──────────────────────────────────────────────────────
+
+function loadBestTimes(): Record<Difficulty, number | null> {
+  try {
+    const raw = localStorage.getItem(BEST_TIMES_KEY);
+    if (!raw) return buildEmptyBestTimes();
+    const parsed = JSON.parse(raw) as Record<Difficulty, number | null>;
+    return parsed;
+  } catch {
+    return buildEmptyBestTimes();
+  }
+}
+
+function saveBestTimes(bestTimes: Record<Difficulty, number | null>): void {
+  try {
+    localStorage.setItem(BEST_TIMES_KEY, JSON.stringify(bestTimes));
+  } catch {
+    // NOTE: localStorage may be unavailable in some environments — fail silently
+  }
+}
+
+function buildEmptyBestTimes(): Record<Difficulty, number | null> {
+  return {
+    [Difficulty.Easy]: null,
+    [Difficulty.Medium]: null,
+    [Difficulty.Hard]: null,
+  };
+}
+
+// ── Initial state factory ─────────────────────────────────────────────────────
+
+function buildIdleState(
+  difficulty: Difficulty,
+  bestTimes: Record<Difficulty, number | null>,
+): GameState {
+  const { rows, cols, mines } = DIFFICULTY_CONFIG[difficulty];
+  return {
+    board: createEmptyBoard(rows, cols),
+    status: GameStatus.Idle,
+    difficulty,
+    flagsRemaining: mines,
+    elapsedSeconds: 0,
+    bestTimes,
+    shakingCell: null,
+    explosionQueue: [],
+  };
+}
+
+export function buildInitialState(difficulty = Difficulty.Easy): GameState {
+  return buildIdleState(difficulty, loadBestTimes());
+}
+
+// ── Mine cells ordered for explosion animation ────────────────────────────────
+
+function collectMineCells(board: Cell[][]): Cell[] {
+  return board.flat().filter((cell) => cell.isMine);
+}
+
+// ── Reducer ───────────────────────────────────────────────────────────────────
+
+export function gameReducer(state: GameState, action: GameAction): GameState {
+  switch (action.type) {
+    case "START_GAME": {
+      return buildIdleState(action.difficulty, state.bestTimes);
+    }
+
+    case "REVEAL_CELL": {
+      const { row, col } = action;
+      const cell = state.board[row][col];
+
+      // Ignore clicks on already-revealed or flagged cells and terminal states
+      if (
+        cell.state !== CellState.Hidden ||
+        state.status === GameStatus.Won ||
+        state.status === GameStatus.Lost
+      ) {
+        return state;
+      }
+
+      // First click: place mines and start the clock
+      const isFirstClick = state.status === GameStatus.Idle;
+      let board = state.board;
+
+      if (isFirstClick) {
+        board = placeMines(board, DIFFICULTY_CONFIG[state.difficulty].mines, row, col);
+        board = computeAdjacentCounts(board);
+      }
+
+      // Reveal the clicked cell
+      board = revealCell(board, row, col);
+      const revealedCell = board[row][col];
+
+      // Mine hit → Lost
+      if (revealedCell.isMine) {
+        return {
+          ...state,
+          board,
+          status: GameStatus.Lost,
+          explosionQueue: collectMineCells(board),
+          shakingCell: null,
+        };
+      }
+
+      // Check win condition
+      if (checkWin(board)) {
+        const elapsed = state.elapsedSeconds;
+        const prev = state.bestTimes[state.difficulty];
+        const isNewBest = prev === null || elapsed < prev;
+        const bestTimes = isNewBest
+          ? { ...state.bestTimes, [state.difficulty]: elapsed }
+          : state.bestTimes;
+
+        if (isNewBest) saveBestTimes(bestTimes);
+
+        return {
+          ...state,
+          board,
+          status: GameStatus.Won,
+          bestTimes,
+          shakingCell: null,
+          explosionQueue: [],
+        };
+      }
+
+      return {
+        ...state,
+        board,
+        status: GameStatus.Playing,
+        shakingCell: null,
+        explosionQueue: [],
+      };
+    }
+
+    case "TOGGLE_FLAG": {
+      const { row, col } = action;
+      const cell = state.board[row][col];
+
+      // Only act on hidden cells during an active game
+      if (
+        state.status === GameStatus.Won ||
+        state.status === GameStatus.Lost
+      ) {
+        return state;
+      }
+
+      if (cell.state === CellState.Hidden) {
+        // Block placing a flag when the cap is reached
+        if (state.flagsRemaining === 0) return state;
+
+        const board = state.board.map((r) =>
+          r.map((c) =>
+            c.row === row && c.col === col
+              ? { ...c, state: CellState.Flagged }
+              : c,
+          ),
+        );
+        return { ...state, board, flagsRemaining: state.flagsRemaining - 1 };
+      }
+
+      if (cell.state === CellState.Flagged) {
+        const board = state.board.map((r) =>
+          r.map((c) =>
+            c.row === row && c.col === col
+              ? { ...c, state: CellState.Hidden }
+              : c,
+          ),
+        );
+        return { ...state, board, flagsRemaining: state.flagsRemaining + 1 };
+      }
+
+      return state;
+    }
+
+    case "CHORD_REVEAL": {
+      const { row, col } = action;
+      const cell = state.board[row][col];
+
+      if (
+        state.status !== GameStatus.Playing ||
+        cell.state !== CellState.Revealed ||
+        cell.adjacentMines === 0
+      ) {
+        return state;
+      }
+
+      const flagCount = countAdjacentFlags(state.board, row, col);
+
+      // Mismatch: shake the cell instead of revealing
+      if (flagCount !== cell.adjacentMines) {
+        return { ...state, shakingCell: [row, col] };
+      }
+
+      const { board, triggeredMine } = chordReveal(state.board, row, col);
+
+      if (triggeredMine) {
+        return {
+          ...state,
+          board,
+          status: GameStatus.Lost,
+          explosionQueue: collectMineCells(board),
+          shakingCell: null,
+        };
+      }
+
+      if (checkWin(board)) {
+        const elapsed = state.elapsedSeconds;
+        const prev = state.bestTimes[state.difficulty];
+        const isNewBest = prev === null || elapsed < prev;
+        const bestTimes = isNewBest
+          ? { ...state.bestTimes, [state.difficulty]: elapsed }
+          : state.bestTimes;
+
+        if (isNewBest) saveBestTimes(bestTimes);
+
+        return {
+          ...state,
+          board,
+          status: GameStatus.Won,
+          bestTimes,
+          shakingCell: null,
+          explosionQueue: [],
+        };
+      }
+
+      return { ...state, board, shakingCell: null };
+    }
+
+    case "TICK": {
+      if (state.status !== GameStatus.Playing) return state;
+      return { ...state, elapsedSeconds: state.elapsedSeconds + 1 };
+    }
+
+    case "RESTART": {
+      return buildIdleState(state.difficulty, state.bestTimes);
+    }
+
+    default:
+      return state;
+  }
+}

--- a/src/tests/reducer.test.ts
+++ b/src/tests/reducer.test.ts
@@ -1,0 +1,410 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { gameReducer, buildInitialState, GameAction } from "../context/reducer";
+import { Difficulty, GameStatus, CellState, DIFFICULTY_CONFIG } from "../types";
+import { computeAdjacentCounts, createEmptyBoard, placeMines } from "../logic";
+
+// =============================================================================
+// Mock localStorage so tests run in jsdom without side-effects leaking
+// =============================================================================
+
+const localStorageMock = (() => {
+  let store: Record<string, string> = {};
+  return {
+    getItem: vi.fn((key: string) => store[key] ?? null),
+    setItem: vi.fn((key: string, value: string) => {
+      store[key] = value;
+    }),
+    clear: () => {
+      store = {};
+    },
+  };
+})();
+
+Object.defineProperty(globalThis, "localStorage", { value: localStorageMock });
+
+// =============================================================================
+// Helpers
+// =============================================================================
+
+function dispatch(state = buildInitialState(), action: GameAction) {
+  return gameReducer(state, action);
+}
+
+/** Produces a Playing state after one safe first click on a known-safe board. */
+function playingState() {
+  const state = buildInitialState(Difficulty.Easy);
+  // START_GAME is implicit in buildInitialState — go straight to first reveal
+  return dispatch(state, { type: "REVEAL_CELL", row: 0, col: 0 });
+}
+
+// =============================================================================
+// START_GAME
+// =============================================================================
+
+describe("START_GAME", () => {
+  it("should set status to Idle", () => {
+    const state = dispatch(undefined, {
+      type: "START_GAME",
+      difficulty: Difficulty.Easy,
+    });
+    expect(state.status).toBe(GameStatus.Idle);
+  });
+
+  it("should set flagsRemaining to mine count for the chosen difficulty", () => {
+    const state = dispatch(undefined, {
+      type: "START_GAME",
+      difficulty: Difficulty.Hard,
+    });
+    expect(state.flagsRemaining).toBe(DIFFICULTY_CONFIG[Difficulty.Hard].mines);
+  });
+
+  it("should create an empty board with no mines", () => {
+    const state = dispatch(undefined, {
+      type: "START_GAME",
+      difficulty: Difficulty.Easy,
+    });
+    expect(state.board.flat().every((c) => !c.isMine)).toBe(true);
+  });
+
+  it("should preserve bestTimes from previous state", () => {
+    const base = buildInitialState();
+    const withTime = {
+      ...base,
+      bestTimes: { ...base.bestTimes, [Difficulty.Easy]: 42 },
+    };
+    const state = gameReducer(withTime, {
+      type: "START_GAME",
+      difficulty: Difficulty.Easy,
+    });
+    expect(state.bestTimes[Difficulty.Easy]).toBe(42);
+  });
+});
+
+// =============================================================================
+// REVEAL_CELL
+// =============================================================================
+
+describe("REVEAL_CELL", () => {
+  beforeEach(() => localStorageMock.clear());
+
+  it("should place mines on first click and set status to Playing", () => {
+    const state = buildInitialState();
+    const next = dispatch(state, { type: "REVEAL_CELL", row: 0, col: 0 });
+    expect(next.status).toBe(GameStatus.Playing);
+    expect(next.board.flat().some((c) => c.isMine)).toBe(true);
+  });
+
+  it("should reveal the clicked cell", () => {
+    const next = playingState();
+    // (0,0) is safe — first click guarantee
+    expect(next.board[0][0].state).toBe(CellState.Revealed);
+  });
+
+  it("should not place a mine on the first-clicked cell", () => {
+    const next = playingState();
+    expect(next.board[0][0].isMine).toBe(false);
+  });
+
+  it("should set status to Lost when a mine is revealed", () => {
+    // Build a board with a known mine and manually reach Playing
+    let board = createEmptyBoard(8, 8);
+    board[3][3].isMine = true;
+    board = computeAdjacentCounts(board);
+    const state: ReturnType<typeof buildInitialState> = {
+      ...buildInitialState(),
+      board,
+      status: GameStatus.Playing,
+    };
+    const next = dispatch(state, { type: "REVEAL_CELL", row: 3, col: 3 });
+    expect(next.status).toBe(GameStatus.Lost);
+  });
+
+  it("should populate explosionQueue on loss", () => {
+    let board = createEmptyBoard(8, 8);
+    board[3][3].isMine = true;
+    board[4][4].isMine = true;
+    board = computeAdjacentCounts(board);
+    const state: ReturnType<typeof buildInitialState> = {
+      ...buildInitialState(),
+      board,
+      status: GameStatus.Playing,
+    };
+    const next = dispatch(state, { type: "REVEAL_CELL", row: 3, col: 3 });
+    expect(next.explosionQueue.length).toBe(2);
+    expect(next.explosionQueue.every((c) => c.isMine)).toBe(true);
+  });
+
+  it("should set status to Won when last safe cell is revealed", () => {
+    // 2×2 board with one mine, reveal the remaining three cells
+    let board = createEmptyBoard(2, 2);
+    board[0][0].isMine = true;
+    board = computeAdjacentCounts(board);
+    board[0][1].state = CellState.Revealed;
+    board[1][0].state = CellState.Revealed;
+    const state: ReturnType<typeof buildInitialState> = {
+      ...buildInitialState(),
+      board,
+      status: GameStatus.Playing,
+      elapsedSeconds: 30,
+    };
+    const next = dispatch(state, { type: "REVEAL_CELL", row: 1, col: 1 });
+    expect(next.status).toBe(GameStatus.Won);
+  });
+
+  it("should update bestTimes on win when no previous record exists", () => {
+    let board = createEmptyBoard(2, 2);
+    board[0][0].isMine = true;
+    board = computeAdjacentCounts(board);
+    board[0][1].state = CellState.Revealed;
+    board[1][0].state = CellState.Revealed;
+    const state: ReturnType<typeof buildInitialState> = {
+      ...buildInitialState(),
+      board,
+      status: GameStatus.Playing,
+      elapsedSeconds: 30,
+    };
+    const next = dispatch(state, { type: "REVEAL_CELL", row: 1, col: 1 });
+    expect(next.bestTimes[Difficulty.Easy]).toBe(30);
+    expect(localStorageMock.setItem).toHaveBeenCalled();
+  });
+
+  it("should not update bestTimes when new time is worse than previous record", () => {
+    let board = createEmptyBoard(2, 2);
+    board[0][0].isMine = true;
+    board = computeAdjacentCounts(board);
+    board[0][1].state = CellState.Revealed;
+    board[1][0].state = CellState.Revealed;
+    const state: ReturnType<typeof buildInitialState> = {
+      ...buildInitialState(),
+      board,
+      status: GameStatus.Playing,
+      elapsedSeconds: 99,
+      bestTimes: { ...buildInitialState().bestTimes, [Difficulty.Easy]: 20 },
+    };
+    const next = dispatch(state, { type: "REVEAL_CELL", row: 1, col: 1 });
+    expect(next.bestTimes[Difficulty.Easy]).toBe(20);
+  });
+
+  it("should ignore clicks on revealed cells", () => {
+    let board = createEmptyBoard(8, 8);
+    board = computeAdjacentCounts(board);
+    board[1][1].state = CellState.Revealed;
+    const state: ReturnType<typeof buildInitialState> = {
+      ...buildInitialState(),
+      board,
+      status: GameStatus.Playing,
+    };
+    const next = dispatch(state, { type: "REVEAL_CELL", row: 1, col: 1 });
+    expect(next).toBe(state);
+  });
+
+  it("should ignore clicks when game is Won or Lost", () => {
+    const won = { ...buildInitialState(), status: GameStatus.Won };
+    const lost = { ...buildInitialState(), status: GameStatus.Lost };
+    expect(dispatch(won, { type: "REVEAL_CELL", row: 0, col: 0 })).toBe(won);
+    expect(dispatch(lost, { type: "REVEAL_CELL", row: 0, col: 0 })).toBe(lost);
+  });
+});
+
+// =============================================================================
+// TOGGLE_FLAG
+// =============================================================================
+
+describe("TOGGLE_FLAG", () => {
+  it("should flag a hidden cell and decrement flagsRemaining", () => {
+    const state = playingState();
+    const target = state.board.flat().find((c) => c.state === CellState.Hidden)!;
+    const next = dispatch(state, {
+      type: "TOGGLE_FLAG",
+      row: target.row,
+      col: target.col,
+    });
+    expect(next.board[target.row][target.col].state).toBe(CellState.Flagged);
+    expect(next.flagsRemaining).toBe(state.flagsRemaining - 1);
+  });
+
+  it("should unflag a flagged cell and increment flagsRemaining", () => {
+    const state = playingState();
+    const target = state.board.flat().find((c) => c.state === CellState.Hidden)!;
+    const flagged = dispatch(state, {
+      type: "TOGGLE_FLAG",
+      row: target.row,
+      col: target.col,
+    });
+    const unflagged = dispatch(flagged, {
+      type: "TOGGLE_FLAG",
+      row: target.row,
+      col: target.col,
+    });
+    expect(unflagged.board[target.row][target.col].state).toBe(
+      CellState.Hidden,
+    );
+    expect(unflagged.flagsRemaining).toBe(state.flagsRemaining);
+  });
+
+  it("should block placing a flag when flagsRemaining is 0", () => {
+    const state = { ...playingState(), flagsRemaining: 0 };
+    const target = state.board.flat().find((c) => c.state === CellState.Hidden)!;
+    const next = dispatch(state, {
+      type: "TOGGLE_FLAG",
+      row: target.row,
+      col: target.col,
+    });
+    expect(next).toBe(state);
+  });
+
+  it("should not flag a revealed cell", () => {
+    const state = playingState();
+    // (0,0) was revealed by first click
+    const next = dispatch(state, { type: "TOGGLE_FLAG", row: 0, col: 0 });
+    expect(next).toBe(state);
+  });
+
+  it("should ignore flags in Won or Lost state", () => {
+    const won = { ...buildInitialState(), status: GameStatus.Won };
+    const next = dispatch(won, { type: "TOGGLE_FLAG", row: 0, col: 0 });
+    expect(next).toBe(won);
+  });
+});
+
+// =============================================================================
+// CHORD_REVEAL
+// =============================================================================
+
+describe("CHORD_REVEAL", () => {
+  it("should set shakingCell when flag count does not match adjacentMines", () => {
+    // 3×3, mine at (0,0), (1,1) is a number cell, no flags placed
+    let board = createEmptyBoard(3, 3);
+    board[0][0].isMine = true;
+    board = computeAdjacentCounts(board);
+    board[1][1].state = CellState.Revealed;
+    const state: ReturnType<typeof buildInitialState> = {
+      ...buildInitialState(),
+      board,
+      status: GameStatus.Playing,
+    };
+    const next = dispatch(state, { type: "CHORD_REVEAL", row: 1, col: 1 });
+    expect(next.shakingCell).toEqual([1, 1]);
+  });
+
+  it("should chord-reveal neighbours when flag count matches adjacentMines", () => {
+    let board = createEmptyBoard(3, 3);
+    board[0][0].isMine = true;
+    board = computeAdjacentCounts(board);
+    board[1][1].state = CellState.Revealed;
+    board[0][0].state = CellState.Flagged;
+    const state: ReturnType<typeof buildInitialState> = {
+      ...buildInitialState(),
+      board,
+      status: GameStatus.Playing,
+      flagsRemaining: 7,
+    };
+    const next = dispatch(state, { type: "CHORD_REVEAL", row: 1, col: 1 });
+    expect(next.shakingCell).toBeNull();
+    // At least one previously hidden neighbour should now be revealed
+    expect(
+      next.board.flat().some(
+        (c) => c.state === CellState.Revealed && !(c.row === 1 && c.col === 1),
+      ),
+    ).toBe(true);
+  });
+
+  it("should set Lost when chord triggers an unflagged mine", () => {
+    // Mine at (0,0) NOT flagged — chord on (1,1) should trigger it
+    let board = createEmptyBoard(3, 3);
+    board[0][0].isMine = true;
+    board = computeAdjacentCounts(board);
+    board[1][1].state = CellState.Revealed;
+    // Fake the adjacent flag count by flagging a non-mine neighbour
+    board[0][1].state = CellState.Flagged;
+    const state: ReturnType<typeof buildInitialState> = {
+      ...buildInitialState(),
+      board,
+      status: GameStatus.Playing,
+      flagsRemaining: 7,
+    };
+    // adjacentMines of (1,1) is 1, flagCount is 1 (flagged (0,1)) → chord fires
+    const next = dispatch(state, { type: "CHORD_REVEAL", row: 1, col: 1 });
+    expect(next.status).toBe(GameStatus.Lost);
+    expect(next.explosionQueue.length).toBeGreaterThan(0);
+  });
+
+  it("should ignore CHORD_REVEAL when game is not Playing", () => {
+    const state = buildInitialState(); // Idle
+    const next = dispatch(state, { type: "CHORD_REVEAL", row: 0, col: 0 });
+    expect(next).toBe(state);
+  });
+});
+
+// =============================================================================
+// TICK
+// =============================================================================
+
+describe("TICK", () => {
+  it("should increment elapsedSeconds when Playing", () => {
+    const state = { ...playingState(), elapsedSeconds: 5 };
+    const next = dispatch(state, { type: "TICK" });
+    expect(next.elapsedSeconds).toBe(6);
+  });
+
+  it("should not increment elapsedSeconds when Idle", () => {
+    const state = buildInitialState();
+    const next = dispatch(state, { type: "TICK" });
+    expect(next).toBe(state);
+  });
+
+  it("should not increment elapsedSeconds when Won", () => {
+    const state = { ...buildInitialState(), status: GameStatus.Won, elapsedSeconds: 10 };
+    const next = dispatch(state, { type: "TICK" });
+    expect(next).toBe(state);
+  });
+
+  it("should not increment elapsedSeconds when Lost", () => {
+    const state = { ...buildInitialState(), status: GameStatus.Lost, elapsedSeconds: 10 };
+    const next = dispatch(state, { type: "TICK" });
+    expect(next).toBe(state);
+  });
+});
+
+// =============================================================================
+// RESTART
+// =============================================================================
+
+describe("RESTART", () => {
+  it("should reset board, status, and timer", () => {
+    const state = { ...playingState(), elapsedSeconds: 42 };
+    const next = dispatch(state, { type: "RESTART" });
+    expect(next.status).toBe(GameStatus.Idle);
+    expect(next.elapsedSeconds).toBe(0);
+    expect(next.board.flat().every((c) => !c.isMine)).toBe(true);
+  });
+
+  it("should preserve difficulty", () => {
+    const state = dispatch(buildInitialState(), {
+      type: "START_GAME",
+      difficulty: Difficulty.Hard,
+    });
+    const next = dispatch(state, { type: "RESTART" });
+    expect(next.difficulty).toBe(Difficulty.Hard);
+  });
+
+  it("should preserve bestTimes", () => {
+    const state = {
+      ...buildInitialState(),
+      bestTimes: { ...buildInitialState().bestTimes, [Difficulty.Easy]: 15 },
+    };
+    const next = dispatch(state, { type: "RESTART" });
+    expect(next.bestTimes[Difficulty.Easy]).toBe(15);
+  });
+
+  it("should reset shakingCell and explosionQueue", () => {
+    const state = {
+      ...buildInitialState(),
+      shakingCell: [2, 2] as [number, number],
+      explosionQueue: [buildInitialState().board[0][0]],
+    };
+    const next = dispatch(state, { type: "RESTART" });
+    expect(next.shakingCell).toBeNull();
+    expect(next.explosionQueue).toHaveLength(0);
+  });
+});

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -54,4 +54,8 @@ export type GameState = {
   flagsRemaining: number;
   elapsedSeconds: number;
   bestTimes: Record<Difficulty, number | null>;
+  /** Coordinate of the cell to animate with a shake (chord mismatch). Cleared after animation. */
+  shakingCell: [number, number] | null;
+  /** Ordered queue of mine cells to reveal sequentially during loss animation. */
+  explosionQueue: Cell[];
 };


### PR DESCRIPTION
## Summary

Implements **#4 — Game State Reducer**.

## Changes

- `src/types/index.ts` — adds `shakingCell: [number, number] | null` and `explosionQueue: Cell[]` to `GameState` (deferred from issue #2 as noted in CR)
- `src/context/reducer.ts` — `GameAction` union type, `gameReducer`, `buildInitialState`, localStorage helpers
- `src/tests/reducer.test.ts` — 28 unit tests covering all action types and edge cases

## Acceptance Criteria

- [x] Action types defined: `START_GAME`, `REVEAL_CELL`, `TOGGLE_FLAG`, `CHORD_REVEAL`, `TICK`, `RESTART`
- [x] `START_GAME` initialises empty board and sets status to `Idle`
- [x] `REVEAL_CELL` on first click places mines, sets `Playing`, reveals cell
- [x] `REVEAL_CELL` on mine sets `Lost` and populates `explosionQueue`
- [x] `REVEAL_CELL` checks win and updates `bestTimes` + localStorage on new record
- [x] `TOGGLE_FLAG` toggles flag, blocked when `flagsRemaining === 0`, increments on unflag
- [x] `CHORD_REVEAL` sets `shakingCell` on mismatch, reveals on match, sets `Lost` on mine
- [x] `TICK` increments `elapsedSeconds` only when `Playing`
- [x] `RESTART` resets board and timer, preserves `difficulty` and `bestTimes`
- [x] Unit tests cover all action types and edge cases

## Related Issue

Closes #4